### PR TITLE
Add timepoint field

### DIFF
--- a/interpolate-blank-stop-times/UsersGuide.md
+++ b/interpolate-blank-stop-times/UsersGuide.md
@@ -70,7 +70,7 @@ This method is fairly simplistic, but it should provide a reasonable estimate fo
 - **Output stop_times.txt file**: Your new stop_times.txt file with estimated values for arrival_time and departure_time filled in.  It is recommended to not overwrite your original stop_times.txt file. Save the output with a new file name so you can double check the results before replacing your original file.
 
 ###Outputs
-- **[Your designated output stop_times.txt file]**: The output stop_times.txt file is identical to your original stop_times.txt file except that all blank arrival_time and departure_time values have been filled in.
+- **[Your designated output stop_times.txt file]**: The output stop_times.txt file is identical to your original stop_times.txt file except that all blank arrival_time and departure_time values have been filled in.  A timepoint field will be added if none was previously present, and it will be filled in with values of 0 (meaning that times are considered approximate) for the interpolated times.
 
 ###Troubleshooting & potential pitfalls
 * The tool takes forever to run: For small stop_times.txt files and for files with only a small number of blank stop times, this tool will run fairly quickly.  However, this tool will take a considerable time to run for very large datasets with a large number of blank times.  It may take many hours to complete.  Progress is reported in  increments of 10%.

--- a/interpolate-blank-stop-times/scripts/simple_interpolate.py
+++ b/interpolate-blank-stop-times/scripts/simple_interpolate.py
@@ -164,7 +164,7 @@ start with!")
                 current_blank_times.append(stop_formatted)
             
         # Update SQL table with the interpolated values
-        UpdateStmt = "UPDATE stop_times SET arrival_time=?,departure_time=? WHERE sqliteprimarykeyid=?"
+        UpdateStmt = "UPDATE stop_times SET arrival_time=?,departure_time=?,timepoint=0 WHERE sqliteprimarykeyid=?"
         c.executemany(UpdateStmt, updated_tripinfo)
         conn.commit()
     

--- a/interpolate-blank-stop-times/scripts/simple_interpolate.py
+++ b/interpolate-blank-stop-times/scripts/simple_interpolate.py
@@ -1,7 +1,7 @@
 ############################################################################
 ## Tool name: Simple interpolation
 ## Created by: Melinda Morang, Esri, mmorang@esri.com
-## Last updated: 11 March 2016
+## Last updated: 9 August 2017
 ############################################################################
 '''
 This tool assigns values to blank arrival_time and departure_time values in the
@@ -11,7 +11,7 @@ time values.  This simple method does not consider the distance or drive time
 between stops.
 '''
 ################################################################################
-'''Copyright 2016 Esri
+'''Copyright 2017 Esri
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at

--- a/interpolate-blank-stop-times/scripts/sqlize_stop_times.py
+++ b/interpolate-blank-stop-times/scripts/sqlize_stop_times.py
@@ -1,7 +1,7 @@
 ############################################################################
 ## Tool name: Preproces stop_times
 ## Created by: Melinda Morang, Esri, mmorang@esri.com
-## Last updated: 11 March 2016
+## Last updated: 9 August 2017
 ############################################################################
 '''
 This tool creates a SQL table from a GTFS stop_times.txt file and analyzes
@@ -10,7 +10,7 @@ table can be used as input to other tools to replace the blank values with
 interpolated estimates.
 '''
 ################################################################################
-'''Copyright 2016 Esri
+'''Copyright 2017 Esri
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at

--- a/interpolate-blank-stop-times/scripts/sqlize_stop_times.py
+++ b/interpolate-blank-stop-times/scripts/sqlize_stop_times.py
@@ -64,11 +64,13 @@ try:
             if not col in columns:
                 arcpy.AddError("Your GTFS dataset's stop_times.txt file is missing a required column: %s" % col)
                 raise CustomError
-        
+
         # Create the SQL database and table with the appropriate schema
         for col in columns:
             if col in relevant_cols:
                 table_schema += relevant_cols[col]
+            elif col == "timepoint":
+                table_schema += col + " INT,\n"
             else:
                 table_schema += col + " CHAR,\n"
         table_schema = table_schema.strip(",\n")
@@ -87,6 +89,10 @@ try:
                             , reader)
         conn.commit()
         
+        # Add the optional timepoint column if it isn't already there
+        if not "timepoint" in columns:
+            c.execute("ALTER TABLE stop_times ADD timepoint INT;")
+
         # Create indices to speed up searching later
         c.execute("CREATE INDEX idx_arrivaltime ON stop_times (arrival_time);")
         c.execute("CREATE INDEX idx_departuretime ON stop_times (departure_time);")


### PR DESCRIPTION
The timepoint field was added to the GTFS spec recently.  Update tool so that interpolated times populate the timepoint field with a value of 0 to indicate that the times are considered approximate.