### PR TITLE
BetterBusBuffers: Fix handling trips from tomorrow and yesterday

### DIFF
--- a/better-bus-buffers/scripts/BBB_AnalyzeIndividualRoute_Step2.py
+++ b/better-bus-buffers/scripts/BBB_AnalyzeIndividualRoute_Step2.py
@@ -193,6 +193,8 @@ fields %s. Please choose a valid feature class." % (FC, str(RequiredFields)))
             BBB_SharedFunctions.GetServiceIDListsAndNonOverlaps(day, start_sec, end_sec, DepOrArr, Specific)
 
         trip_route_dict = {} #{(route_id, direction_id): [trip_id, trip_id,..]}
+        trip_route_dict_yest = {}
+        trip_route_dict_tom = {}
         for rtpair in route_dir_list:
             key = tuple(rtpair)
             route_id = rtpair[0]
@@ -223,10 +225,14 @@ the values will be 0 or <Null>." % (route_id, str(direction_id)))
 
             for triproute in triproutelist:
                 # Only keep trips running on the correct day
-                if triproute[1] in serviceidlist or triproute[1] in serviceidlist_tom or triproute[1] in serviceidlist_yest:
+                if triproute[1] in serviceidlist:
                     trip_route_dict.setdefault(key, []).append(triproute[0])
+                if triproute[1] in serviceidlist_tom:
+                    trip_route_dict_tom.setdefault(key, []).append(triproute[0])
+                if triproute[1] in serviceidlist_yest:
+                    trip_route_dict_yest.setdefault(key, []).append(triproute[0])
 
-            if not trip_route_dict:
+            if not trip_route_dict and not trip_route_dict_tom and not trip_route_dict_yest:
                 arcpy.AddWarning("There is no service for route %s in direction %s \
 on %s during the time window you selected. Output fields will be generated, but \
 the values will be 0 or <Null>." % (route_id, str(direction_id), str(day)))
@@ -241,13 +247,27 @@ the values will be 0 or <Null>." % (route_id, str(direction_id), str(day)))
         arcpy.AddMessage("Calculating the number of transit trips available during the time window...")
 
         stoptimedict_rtdirpair = {}
-        for rtdirpair in trip_route_dict:
-            triplist = trip_route_dict[rtdirpair]
+        for rtdirpair in list(set([rt for rt in trip_route_dict.keys() + trip_route_dict_yest.keys() + trip_route_dict_tom.keys()])):
 
             # Get the stop_times that occur during this time window
-            stoptimedict = BBB_SharedFunctions.GetStopTimesForStopsInTimeWindow(start_sec, end_sec, DepOrArr, triplist, "today")
-            stoptimedict_yest = BBB_SharedFunctions.GetStopTimesForStopsInTimeWindow(start_sec, end_sec, DepOrArr, triplist, "yesterday")
-            stoptimedict_tom = BBB_SharedFunctions.GetStopTimesForStopsInTimeWindow(start_sec, end_sec, DepOrArr, triplist, "tomorrow")
+            stoptimedict = {}
+            stoptimedict_yest = {}
+            stoptimedict_tom = {}
+            try:
+                triplist = trip_route_dict[rtdirpair]
+                stoptimedict = BBB_SharedFunctions.GetStopTimesForStopsInTimeWindow(start_sec, end_sec, DepOrArr, triplist, "today")
+            except KeyError: # No trips
+                pass
+            try:
+                triplist_yest = trip_route_dict_yest[rtdirpair]
+                stoptimedict_yest = BBB_SharedFunctions.GetStopTimesForStopsInTimeWindow(start_sec, end_sec, DepOrArr, triplist_yest, "yesterday")
+            except KeyError: # No trips
+                pass
+            try:
+                triplist_tom = trip_route_dict_tom[rtdirpair]
+                stoptimedict_tom = BBB_SharedFunctions.GetStopTimesForStopsInTimeWindow(start_sec, end_sec, DepOrArr, triplist_tom, "tomorrow")
+            except KeyError: # No trips
+                pass
 
             # Combine the three dictionaries into one master
             for stop in stoptimedict_yest:

--- a/better-bus-buffers/scripts/BBB_CountHighFrequencyRoutesAtStops.py
+++ b/better-bus-buffers/scripts/BBB_CountHighFrequencyRoutesAtStops.py
@@ -191,6 +191,8 @@ You have ArcGIS Pro version %s." % BBB_SharedFunctions.ArcVersion)
 
         trip_route_warning_counter = 0
         trip_route_dict = {}  # {(route_id, direction_id): [trip_id, trip_id,..]}
+        trip_route_dict_yest = {}
+        trip_route_dict_tom = {}
         triproutelist = []
         for rtpair in route_dir_list:
             key = tuple(rtpair)
@@ -220,35 +222,49 @@ the values will be 0 or <Null>." % (route_id, str(direction_id)))
 
             for triproute in triproutelist:
                 # Only keep trips running on the correct day
+                if triproute[1] in serviceidlist:
+                    trip_route_dict.setdefault(key, []).append(triproute[0])
+                if triproute[1] in serviceidlist_tom:
+                    trip_route_dict_tom.setdefault(key, []).append(triproute[0])
+                if triproute[1] in serviceidlist_yest:
+                    trip_route_dict_yest.setdefault(key, []).append(triproute[0])
 
-                if triproute[1] in serviceidlist or triproute[1] in serviceidlist_tom or triproute[
-                    1] in serviceidlist_yest:
-                    trip_route_dict.setdefault(key, []).append(triproute[0])  # {(rtdirpair): [trip_id, trip_id,..]}
-
-            if not trip_route_dict:
+            if not trip_route_dict and not trip_route_dict_tom and not trip_route_dict_yest:
                 arcpy.AddWarning("There is no service for route %s in direction %s \
 on %s during the time window you selected. Output fields will be generated, but \
 the values will be 0 or <Null>." % (route_id, str(direction_id), str(day)))
 
-
     except:
         arcpy.AddError("Error getting trips associated with route.")
         raise
+
+
     # ----- Query the GTFS data to count the trips at each stop for this time period -----
     try:
         arcpy.AddMessage("Calculating the number of transit trips available during the time window of time period ID {0}...".format(str(time_period)))
         stoptimedict_rtedirpair = {}  # #{rtdir tuple:stoptimedict}}
         stoptimedict_service_check_counter=0
-        for rtedirpair in trip_route_dict:
-            triplist = trip_route_dict[rtedirpair]
-
+        for rtdirpair in list(set([rt for rt in trip_route_dict.keys() + trip_route_dict_yest.keys() + trip_route_dict_tom.keys()])):
+            
             # Get the stop_times that occur during this time window
-            stoptimedict = BBB_SharedFunctions.GetStopTimesForStopsInTimeWindow(start_sec, end_sec, DepOrArr,
-                                                                                triplist, "today")
-            stoptimedict_yest = BBB_SharedFunctions.GetStopTimesForStopsInTimeWindow(start_sec, end_sec, DepOrArr,
-                                                                                     triplist, "yesterday")
-            stoptimedict_tom = BBB_SharedFunctions.GetStopTimesForStopsInTimeWindow(start_sec, end_sec, DepOrArr,
-                                                                                    triplist, "tomorrow")
+            stoptimedict = {}
+            stoptimedict_yest = {}
+            stoptimedict_tom = {}
+            try:
+                triplist = trip_route_dict[rtdirpair]
+                stoptimedict = BBB_SharedFunctions.GetStopTimesForStopsInTimeWindow(start_sec, end_sec, DepOrArr, triplist, "today")
+            except KeyError: # No trips
+                pass
+            try:
+                triplist_yest = trip_route_dict_yest[rtdirpair]
+                stoptimedict_yest = BBB_SharedFunctions.GetStopTimesForStopsInTimeWindow(start_sec, end_sec, DepOrArr, triplist_yest, "yesterday")
+            except KeyError: # No trips
+                pass
+            try:
+                triplist_tom = trip_route_dict_tom[rtdirpair]
+                stoptimedict_tom = BBB_SharedFunctions.GetStopTimesForStopsInTimeWindow(start_sec, end_sec, DepOrArr, triplist_tom, "tomorrow")
+            except KeyError: # No trips
+                pass
 
             # Combine the three dictionaries into one master
             for stop in stoptimedict_yest:  # Update Dictionaries based on setdefault returns values.
@@ -256,7 +272,7 @@ the values will be 0 or <Null>." % (route_id, str(direction_id), str(day)))
             for stop in stoptimedict_tom:
                 stoptimedict[stop] = stoptimedict.setdefault(stop, []) + stoptimedict_tom[stop]
             # PD here
-            stoptimedict_rtedirpair[rtedirpair] = stoptimedict  # {rtdir tuple:{stoptimedict}}
+            stoptimedict_rtedirpair[rtdirpair] = stoptimedict  # {rtdir tuple:{stoptimedict}}
             # Add a minor warning if there is no service for at least one route-direction combination.
             if not stoptimedict:
                 stoptimedict_service_check_counter+=1

--- a/better-bus-buffers/scripts/BBB_SharedFunctions.py
+++ b/better-bus-buffers/scripts/BBB_SharedFunctions.py
@@ -403,8 +403,8 @@ No trips are running.")
     try:
         # Get the stop_times that occur during this time window
         stoptimedict = GetStopTimesForStopsInTimeWindow(start_sec, end_sec, DepOrArr, triplist, "today")
-        stoptimedict_yest = GetStopTimesForStopsInTimeWindow(start_sec, end_sec, DepOrArr, triplist, "yesterday")
-        stoptimedict_tom = GetStopTimesForStopsInTimeWindow(start_sec, end_sec, DepOrArr, triplist, "tomorrow")
+        stoptimedict_yest = GetStopTimesForStopsInTimeWindow(start_sec, end_sec, DepOrArr, triplist_yest, "yesterday")
+        stoptimedict_tom = GetStopTimesForStopsInTimeWindow(start_sec, end_sec, DepOrArr, triplist_tom, "tomorrow")
 
         # Combine the three dictionaries into one master
         for stop in stoptimedict_yest:


### PR DESCRIPTION
In the CountTripsAtStops() function in BBB_SharedFunctions.py, it makes a list of all the trips that are running on the day designated for the analysis, and then it also grabs lists of trips for the previous day and the following day because of the way service can wrap around (ie, trips that began in the late hours of yesterday can still be running in the early hours of this morning).
 
After getting those trip lists, it calls another function that runs a SQL query to get all the stop times on those trips that are within the time window.  I think I made a copy-paste error here a long time ago.  I was feeding today’s trip list into the calls to this function for yesterday and tomorrow, when I should have been feeding the lists for yesterday and tomorrow, respectively.

This would cause incorrect stop time counts under the following circumstances:
- The time window is in the early hours of the morning when trips from the previous day are still running (eg. 00:00-04:00), or the time window extends past 24:00 into the early hours of the following morning (eg. 22:00-26:00).
- The transit agency actually has trips running in the early hours of the morning.  If no service, no problem.
- The list of trips running on the previous day and/or following day is different than the list of trips running on the day chosen for the analysis.  This would be unlikely if you chose, for example, Wednesday, because most agencies with a regular weekday schedule will have the same trips running on Tuesday and Thursday as on Wednesday.  It would be more likely if you were running on a weekend or a Monday or if the previous or following day is a holiday.