### PR TITLE
Select_analysis vs. analysis.Select

### DIFF
--- a/add-GTFS-to-a-network-dataset/scripts/GenerateStop2StreetConnectors.py
+++ b/add-GTFS-to-a-network-dataset/scripts/GenerateStop2StreetConnectors.py
@@ -150,7 +150,7 @@ try:
         SelectionMessage = "Stops will snap only to street features where the \
 following is true: " + SelectExpression
         arcpy.AddMessage(SelectionMessage)
-    arcpy.analysis.Select(Streets, outTempSelection, SelectExpression)
+    arcpy.Select_analysis(Streets, outTempSelection, SelectExpression)
 
     # Snap the stops to the streets network, using the snapping tolerance
     # specified in the user's input.


### PR DESCRIPTION
I am noticing a bug on my side with the selecting functionality when running the tool. I am starting to wonder if this method of calling the analysis library is old?
https://desktop.arcgis.com/en/arcmap/10.3/tools/analysis-toolbox/select.htm

Can you provide your thoughts on this? 