### PR TITLE
Replace polyline object with lat/lon list

### DIFF
--- a/generate-GTFS-shapes/scripts/Step1_MakeShapesFC.py
+++ b/generate-GTFS-shapes/scripts/Step1_MakeShapesFC.py
@@ -1406,13 +1406,7 @@ def append_existing_shape_to_fc(shape, StopsCursor, route=None):
     cp.execute(pointsinshapefetch)
     
     # Create the polyline feature from the sequence of points
-    array = arcpy.Array()
-    pt = arcpy.Point()
-    for point in cp:
-        pt.X = float(point[1])
-        pt.Y = float(point[0])
-        array.add(pt)
-    polyline = arcpy.Polyline(array)
+    polyline = [(float(point[1]), float(point[0])) for point in cp]
 
     # Add the polyline feature to the output feature class
     StopsCursor.insertRow((polyline, shape, route,


### PR DESCRIPTION
When creating shape features from existing shapes.txt file, don't use a polyline object.  Just pass in the lat/lon points directly to the cursor.  This works faster.  Also, it resolves a strange issue where the output polylines were missing a lot of vertices.  The polyline was doing some kind of simplification behind the scenes that didn't make sense.