### PR TITLE
For unknown route_type values, use int instead of str

### DIFF
--- a/generate-GTFS-shapes/scripts/Step1_MakeShapesFC.py
+++ b/generate-GTFS-shapes/scripts/Step1_MakeShapesFC.py
@@ -1303,7 +1303,7 @@ def get_route_info():
             route_type = route[5]
             route_type_text = route_type_dict[int(route_type)]
         except:
-            route_type = '100'
+            route_type = 100
             route_type_text = "Other / Type not specified"
         RouteDict[route[0]] = [route[1], route[2], route[3], route[4], route_type,
                                  route[6], route[7], route[8],


### PR DESCRIPTION
When the user's data has route_type values that don't match the ones listed in the GTFS spec, my code sets the route_type to 100 as just a random value to track them.  It was setting it to a string value, '100', instead of an integer, and this caused these routes to get ignored later when generating polylines.