### PR TITLE
Improve linear referencing for Stops in Generate GTFS Shapes

### DIFF
--- a/generate-GTFS-shapes/scripts/Step1_MakeShapesFC.py
+++ b/generate-GTFS-shapes/scripts/Step1_MakeShapesFC.py
@@ -1145,21 +1145,21 @@ better output using ArcGIS version 10.3 or higher or ArcGIS Pro 2.0 or higher. Y
 
 
 def get_stop_lat_lon():
-        '''Populate a dictionary of {stop_id: [stop_lat, stop_lon]}'''
-        
-        arcpy.AddMessage("Collecting and processing GTFS stop information...")
-        
-        # Find all stops with lat/lon
-        global stoplatlon_dict
-        stoplatlon_dict = {}
-        cs = conn.cursor()
-        stoplatlonfetch = '''
-            SELECT stop_id, stop_lat, stop_lon FROM stops
-            ;'''
-        cs.execute(stoplatlonfetch)
-        for stop in cs:
-            # Add stop lat/lon to dictionary
-            stoplatlon_dict[stop[0]] = [stop[1], stop[2]]
+    '''Populate a dictionary of {stop_id: [stop_lat, stop_lon]}'''
+    
+    arcpy.AddMessage("Collecting and processing GTFS stop information...")
+    
+    # Find all stops with lat/lon
+    global stoplatlon_dict
+    stoplatlon_dict = {}
+    cs = conn.cursor()
+    stoplatlonfetch = '''
+        SELECT stop_id, stop_lat, stop_lon FROM stops
+        ;'''
+    cs.execute(stoplatlonfetch)
+    for stop in cs:
+        # Add stop lat/lon to dictionary
+        stoplatlon_dict[stop[0]] = [stop[1], stop[2]]
 
 
 def get_stop_geom():


### PR DESCRIPTION
Attempt to use the known sequence information to linear reference more accurately and avoid sequence errors. Linear reference stops in a random order.  When linear referencing a particular stop, extract the line segment between the prior already-linear-referenced stop and the next one and linear reference along that segment only.  If no good solution is found, throw out the point and the prior or next one and try them again later.  Improves solution significantly, slows it down a bit, but is still not guaranteed to be 100% accurate.

Addresses https://github.com/Esri/public-transit-tools/issues/132 to the greatest extent that I have been able to so far with the existing linear referencing tools and python methods available in ArcGIS right now.