### PR TITLE
Update links to GeoNet/Esri Community forum

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project contains tools for working with public transit data in ArcGIS.  Eac
 
 ## Issues
 
-Find a bug or want to request a new feature?  Please let us know by submitting an [issue](../../issues), or post a question in our [GeoNet group](https://community.esri.com/community/arcgis-for-public-transit).
+Find a bug or want to request a new feature?  Please let us know by submitting an [issue](../../issues), or post a question in the [Esri Community forums](https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions).
 
 ## Contributing
 

--- a/add-GTFS-to-a-network-dataset/README.md
+++ b/add-GTFS-to-a-network-dataset/README.md
@@ -45,7 +45,7 @@ To build the GetEIDs tool, you will need to do the same thing with the System.Da
 
 ## Issues
 
-Find a bug or want to request a new feature?  Please let us know by submitting an issue, or post a question in our [GeoNet group](https://community.esri.com/community/arcgis-for-public-transit).
+Find a bug or want to request a new feature?  Please let us know by submitting an issue, or post a question in the [Esri Community forums](https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions).
 
 ## Contributing
 

--- a/add-GTFS-to-a-network-dataset/TroubleshootingGuide.md
+++ b/add-GTFS-to-a-network-dataset/TroubleshootingGuide.md
@@ -33,7 +33,7 @@ This document describes some common problems encountered by users of *Add GTFS t
   - [I upgraded ArcMap to a new version, and now Add GTFS to a Network Dataset.tbx and Transit Analysis Tools.tbx are no longer in ArcToolbox](#ArcMapUpgrade)
   - [The Network Identify tool always shows a cost of -1 for TransitLines edges in my network](#NetworkIdentify)
 
-If you haven't found your answer here, search for answers and post questions in our [GeoNet group](https://community.esri.com/community/arcgis-for-public-transit).
+If you haven't found your answer here, search for answers and post questions in the [Esri Community forums](https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions).
 
 
 ## <a name="Registration"></a>I can't register/install the transit evaluator

--- a/add-GTFS-to-a-network-dataset/UsersGuide.md
+++ b/add-GTFS-to-a-network-dataset/UsersGuide.md
@@ -488,4 +488,4 @@ These tools are exploratory prototypes designed to help Esri further its develop
 Because these are prototype tools and have not been extensively tested, we cannot guarantee that the results of your analyses will be accurate.  Please keep this in mind if you plan to use your analyses your research or publications. You are welcome to contact us to discuss questions or concerns or if you would like more detailed information about how the tools work.
 
 ## Questions or problems?
-Check the [Troubleshooting Guide](https://github.com/Esri/public-transit-tools/blob/master/add-GTFS-to-a-network-dataset/TroubleshootingGuide.md).  If you're still having trouble, search for answers and post questions in our [GeoNet group](https://community.esri.com/community/arcgis-for-public-transit).
+Check the [Troubleshooting Guide](https://github.com/Esri/public-transit-tools/blob/master/add-GTFS-to-a-network-dataset/TroubleshootingGuide.md).  If you're still having trouble, search for answers and post questions in the [Esri Community forums](https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions).

--- a/better-bus-buffers/README.md
+++ b/better-bus-buffers/README.md
@@ -30,7 +30,7 @@ BetterBusBuffers is a toolset to help you quantitatively measure access to publi
 
 ## Issues
 
-Find a bug or want to request a new feature?  Please let us know by submitting an issue, or post a question in our [GeoNet group](https://community.esri.com/community/arcgis-for-public-transit).
+Find a bug or want to request a new feature?  Please let us know by submitting an issue, or post a question in the [Esri Community forums](https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions).
 
 ## Contributing
 

--- a/better-bus-buffers/UsersGuide.md
+++ b/better-bus-buffers/UsersGuide.md
@@ -81,7 +81,7 @@ The *Preprocess GTFS* tool converts your GTFS dataset(s) into a SQL database.  T
   * Alternatively, if you do not wish to use a specific date for your analysis, you can make a copy of your calendar.txt file and modify the data in the file to remove the non-overlapping date ranges.  For example, if your file has a set of service_ids for the summer months and a set for the winter months, and you're interested in analyzing the summer months, delete all the rows with date ranges for the winter months.  Make sure your cleaned up file is still called calendar.txt so the tool recognizes it.
   * If you are analyzing multiple GTFS datasets at a time, and the datasets have non-overlapping date ranges, you will get the same error as you will if service_ids in one dataset have non-overlapping date ranges.  The date range problem is less of an issue (or not an issue at all) if it occurs in different datasets, but you should double-check anyway to make sure you understand your data.
 
-Still having problems?  Search for answers and post questions in our [GeoNet group](https://community.esri.com/community/arcgis-for-public-transit).
+Still having problems?  Search for answers and post questions in the [Esri Community forums](https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions).
 
 
 ## <a name="CountTripsForIndividualRoute"></a>Running *Count Trips for Individual Route*

--- a/display-GTFS-in-ArcGIS/README.md
+++ b/display-GTFS-in-ArcGIS/README.md
@@ -27,7 +27,7 @@ The Display GTFS Stops tool makes a feature class of stops using information fro
 
 ## Issues
 
-Find a bug or want to request a new feature?  Please let us know by submitting an issue, or post a question in our [GeoNet group](https://community.esri.com/community/arcgis-for-public-transit).
+Find a bug or want to request a new feature?  Please let us know by submitting an issue, or post a question in the [Esri Community forums](https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions).
 
 ## Contributing
 

--- a/display-GTFS-in-ArcGIS/UsersGuide.md
+++ b/display-GTFS-in-ArcGIS/UsersGuide.md
@@ -89,4 +89,4 @@ If you want to rearrange the draw order of your different transit shapes, do the
 Coming soon...
 
 ## Questions or problems?
-Search for answers and post questions in our [GeoNet group](https://community.esri.com/community/arcgis-for-public-transit).
+Search for answers and post questions in the [Esri Community forums](https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions).

--- a/docs/AddGTFStoaNetworkDataset.html
+++ b/docs/AddGTFStoaNetworkDataset.html
@@ -110,9 +110,9 @@
               </div>
               <!-- AddToAny END -->
               <p class="leader-1"><small>We appreciate your questions, comments, and suggestions.<br />
-              Please post them to our <a href="https://community.esri.com/community/arcgis-for-public-transit" rel="noopener" target="_blank">GeoNet group.<a></small></p>
+              Please post them to the <a href="https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions" rel="noopener" target="_blank">Esri Community forums.<a></small></p>
               <div class="esri-logo"></div>
-              <p><small>Copyright © 2020 Esri. All rights reserved. | <a href="http://www.esri.com/legal/privacy">Privacy</a> | <a href="http://www.esri.com/legal">Legal</a></small></p>
+              <p><small>Copyright © 2021 Esri. All rights reserved. | <a href="http://www.esri.com/legal/privacy">Privacy</a> | <a href="http://www.esri.com/legal">Legal</a></small></p>
             </div>
           </div>
         </footer>
@@ -133,6 +133,6 @@ a2a_config.color_link_text = "#497671";
 a2a_config.color_link_text_hover = "#497671";
     </script>
     <script async src="https://static.addtoany.com/menu/page.js"></script>
-    
+
   </body>
 </html>

--- a/docs/BetterBusBuffers.html
+++ b/docs/BetterBusBuffers.html
@@ -124,9 +124,9 @@
               </div>
               <!-- AddToAny END -->
               <p class="leader-1"><small>We appreciate your questions, comments, and suggestions.<br />
-              Please post them to our <a href="https://community.esri.com/community/arcgis-for-public-transit" rel="noopener" target="_blank">GeoNet group.<a></small></p>
+              Please post them to the <a href="https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions" rel="noopener" target="_blank">Esri Community forums.<a></small></p>
               <div class="esri-logo"></div>
-              <p><small>Copyright © 2020 Esri. All rights reserved. | <a href="http://www.esri.com/legal/privacy">Privacy</a> | <a href="http://www.esri.com/legal">Legal</a></small></p>
+              <p><small>Copyright © 2021 Esri. All rights reserved. | <a href="http://www.esri.com/legal/privacy">Privacy</a> | <a href="http://www.esri.com/legal">Legal</a></small></p>
             </div>
           </div>
         </footer>
@@ -147,6 +147,6 @@ a2a_config.color_link_text = "#497671";
 a2a_config.color_link_text_hover = "#497671";
     </script>
     <script async src="https://static.addtoany.com/menu/page.js"></script>
-    
+
   </body>
 </html>

--- a/docs/DisplayGTFSinArcGIS.html
+++ b/docs/DisplayGTFSinArcGIS.html
@@ -108,9 +108,9 @@
               </div>
               <!-- AddToAny END -->
               <p class="leader-1"><small>We appreciate your questions, comments, and suggestions.<br />
-              Please post them to our <a href="https://community.esri.com/community/arcgis-for-public-transit" rel="noopener" target="_blank">GeoNet group.<a></small></p>
+              Please post them to the <a href="https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions" rel="noopener" target="_blank">Esri Community forums.<a></small></p>
               <div class="esri-logo"></div>
-              <p><small>Copyright © 2020 Esri. All rights reserved. | <a href="http://www.esri.com/legal/privacy">Privacy</a> | <a href="http://www.esri.com/legal">Legal</a></small></p>
+              <p><small>Copyright © 2021 Esri. All rights reserved. | <a href="http://www.esri.com/legal/privacy">Privacy</a> | <a href="http://www.esri.com/legal">Legal</a></small></p>
             </div>
           </div>
         </footer>
@@ -131,6 +131,6 @@ a2a_config.color_link_text = "#497671";
 a2a_config.color_link_text_hover = "#497671";
     </script>
     <script async src="https://static.addtoany.com/menu/page.js"></script>
-    
+
   </body>
 </html>

--- a/docs/EditGTFSStopLocations.html
+++ b/docs/EditGTFSStopLocations.html
@@ -106,9 +106,9 @@
               </div>
               <!-- AddToAny END -->
               <p class="leader-1"><small>We appreciate your questions, comments, and suggestions.<br />
-              Please post them to our <a href="https://community.esri.com/community/arcgis-for-public-transit" rel="noopener" target="_blank">GeoNet group.<a></small></p>
+              Please post them to the <a href="https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions" rel="noopener" target="_blank">Esri Community forums.<a></small></p>
               <div class="esri-logo"></div>
-              <p><small>Copyright © 2020 Esri. All rights reserved. | <a href="http://www.esri.com/legal/privacy">Privacy</a> | <a href="http://www.esri.com/legal">Legal</a></small></p>
+              <p><small>Copyright © 2021 Esri. All rights reserved. | <a href="http://www.esri.com/legal/privacy">Privacy</a> | <a href="http://www.esri.com/legal">Legal</a></small></p>
             </div>
           </div>
         </footer>
@@ -129,6 +129,6 @@ a2a_config.color_link_text = "#497671";
 a2a_config.color_link_text_hover = "#497671";
     </script>
     <script async src="https://static.addtoany.com/menu/page.js"></script>
-    
+
   </body>
 </html>

--- a/docs/GTFSRTConnector.html
+++ b/docs/GTFSRTConnector.html
@@ -111,9 +111,9 @@
               </div>
               <!-- AddToAny END -->
               <p class="leader-1"><small>We appreciate your questions, comments, and suggestions.<br />
-              Please post them to our <a href="https://community.esri.com/community/arcgis-for-public-transit" rel="noopener" target="_blank">GeoNet group.<a></small></p>
+              Please post them to the <a href="https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions" rel="noopener" target="_blank">Esri Community forums.<a></small></p>
               <div class="esri-logo"></div>
-              <p><small>Copyright © 2020 Esri. All rights reserved. | <a href="http://www.esri.com/legal/privacy">Privacy</a> | <a href="http://www.esri.com/legal">Legal</a></small></p>
+              <p><small>Copyright © 2021 Esri. All rights reserved. | <a href="http://www.esri.com/legal/privacy">Privacy</a> | <a href="http://www.esri.com/legal">Legal</a></small></p>
             </div>
           </div>
         </footer>
@@ -134,6 +134,6 @@ a2a_config.color_link_text = "#497671";
 a2a_config.color_link_text_hover = "#497671";
     </script>
     <script async src="https://static.addtoany.com/menu/page.js"></script>
-    
+
   </body>
 </html>

--- a/docs/GenerateGTFSShapes.html
+++ b/docs/GenerateGTFSShapes.html
@@ -116,9 +116,9 @@
               </div>
               <!-- AddToAny END -->
               <p class="leader-1"><small>We appreciate your questions, comments, and suggestions.<br />
-              Please post them to our <a href="https://community.esri.com/community/arcgis-for-public-transit" rel="noopener" target="_blank">GeoNet group.<a></small></p>
+              Please post them to the <a href="https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions" rel="noopener" target="_blank">Esri Community forums.<a></small></p>
               <div class="esri-logo"></div>
-              <p><small>Copyright © 2020 Esri. All rights reserved. | <a href="http://www.esri.com/legal/privacy">Privacy</a> | <a href="http://www.esri.com/legal">Legal</a></small></p>
+              <p><small>Copyright © 2021 Esri. All rights reserved. | <a href="http://www.esri.com/legal/privacy">Privacy</a> | <a href="http://www.esri.com/legal">Legal</a></small></p>
             </div>
           </div>
         </footer>
@@ -139,6 +139,6 @@ a2a_config.color_link_text = "#497671";
 a2a_config.color_link_text_hover = "#497671";
     </script>
     <script async src="https://static.addtoany.com/menu/page.js"></script>
-    
+
   </body>
 </html>

--- a/docs/InterpolateBlankStopTimes.html
+++ b/docs/InterpolateBlankStopTimes.html
@@ -105,9 +105,9 @@
               </div>
               <!-- AddToAny END -->
               <p class="leader-1"><small>We appreciate your questions, comments, and suggestions.<br />
-              Please post them to our <a href="https://community.esri.com/community/arcgis-for-public-transit" rel="noopener" target="_blank">GeoNet group.<a></small></p>
+              Please post them to the <a href="https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions" rel="noopener" target="_blank">Esri Community forums.<a></small></p>
               <div class="esri-logo"></div>
-              <p><small>Copyright © 2020 Esri. All rights reserved. | <a href="http://www.esri.com/legal/privacy">Privacy</a> | <a href="http://www.esri.com/legal">Legal</a></small></p>
+              <p><small>Copyright © 2021 Esri. All rights reserved. | <a href="http://www.esri.com/legal/privacy">Privacy</a> | <a href="http://www.esri.com/legal">Legal</a></small></p>
             </div>
           </div>
         </footer>
@@ -128,6 +128,6 @@ a2a_config.color_link_text = "#497671";
 a2a_config.color_link_text_hover = "#497671";
     </script>
     <script async src="https://static.addtoany.com/menu/page.js"></script>
-    
+
   </body>
 </html>

--- a/docs/TransitInArcGISPro.html
+++ b/docs/TransitInArcGISPro.html
@@ -110,9 +110,9 @@
               </div>
               <!-- AddToAny END -->
               <p class="leader-1"><small>We appreciate your questions, comments, and suggestions.<br />
-              Please post them to our <a href="https://community.esri.com/community/arcgis-for-public-transit" rel="noopener" target="_blank">GeoNet group.<a></small></p>
+              Please post them to the <a href="https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions" rel="noopener" target="_blank">Esri Community forums.<a></small></p>
               <div class="esri-logo"></div>
-              <p><small>Copyright © 2020 Esri. All rights reserved. | <a href="http://www.esri.com/legal/privacy">Privacy</a> | <a href="http://www.esri.com/legal">Legal</a></small></p>
+              <p><small>Copyright © 2021 Esri. All rights reserved. | <a href="http://www.esri.com/legal/privacy">Privacy</a> | <a href="http://www.esri.com/legal">Legal</a></small></p>
             </div>
           </div>
         </footer>
@@ -133,6 +133,6 @@ a2a_config.color_link_text = "#497671";
 a2a_config.color_link_text_hover = "#497671";
     </script>
     <script async src="https://static.addtoany.com/menu/page.js"></script>
-    
+
   </body>
 </html>

--- a/docs/TransitNetworkAnalysisTools.html
+++ b/docs/TransitNetworkAnalysisTools.html
@@ -117,9 +117,9 @@
               </div>
               <!-- AddToAny END -->
               <p class="leader-1"><small>We appreciate your questions, comments, and suggestions.<br />
-              Please post them to our <a href="https://community.esri.com/community/arcgis-for-public-transit" rel="noopener" target="_blank">GeoNet group.<a></small></p>
+              Please post them to the <a href="https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions" rel="noopener" target="_blank">Esri Community forums.<a></small></p>
               <div class="esri-logo"></div>
-              <p><small>Copyright © 2020 Esri. All rights reserved. | <a href="http://www.esri.com/legal/privacy">Privacy</a> | <a href="http://www.esri.com/legal">Legal</a></small></p>
+              <p><small>Copyright © 2021 Esri. All rights reserved. | <a href="http://www.esri.com/legal/privacy">Privacy</a> | <a href="http://www.esri.com/legal">Legal</a></small></p>
             </div>
           </div>
         </footer>
@@ -140,6 +140,6 @@ a2a_config.color_link_text = "#497671";
 a2a_config.color_link_text_hover = "#497671";
     </script>
     <script async src="https://static.addtoany.com/menu/page.js"></script>
-    
+
   </body>
 </html>

--- a/docs/TransitSolution.html
+++ b/docs/TransitSolution.html
@@ -105,9 +105,9 @@
               </div>
               <!-- AddToAny END -->
               <p class="leader-1"><small>We appreciate your questions, comments, and suggestions.<br />
-              Please post them to our <a href="https://community.esri.com/community/arcgis-for-public-transit" rel="noopener" target="_blank">GeoNet group.<a></small></p>
+              Please post them to the <a href="https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions" rel="noopener" target="_blank">Esri Community forums.<a></small></p>
               <div class="esri-logo"></div>
-              <p><small>Copyright © 2020 Esri. All rights reserved. | <a href="http://www.esri.com/legal/privacy">Privacy</a> | <a href="http://www.esri.com/legal">Legal</a></small></p>
+              <p><small>Copyright © 2021 Esri. All rights reserved. | <a href="http://www.esri.com/legal/privacy">Privacy</a> | <a href="http://www.esri.com/legal">Legal</a></small></p>
             </div>
           </div>
         </footer>
@@ -128,6 +128,6 @@ a2a_config.color_link_text = "#497671";
 a2a_config.color_link_text_hover = "#497671";
     </script>
     <script async src="https://static.addtoany.com/menu/page.js"></script>
-    
+
   </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -169,9 +169,9 @@
               </div>
               <!-- AddToAny END -->
               <p class="leader-1"><small>We appreciate your questions, comments, and suggestions.<br />
-              Please post them to our <a href="https://community.esri.com/community/arcgis-for-public-transit" rel="noopener" target="_blank">GeoNet group.<a></small></p>
+              Please post them to the <a href="https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions" rel="noopener" target="_blank">Esri Community forums.<a></small></p>
               <div class="esri-logo"></div>
-              <p><small>Copyright © 2020 Esri. All rights reserved. | <a href="http://www.esri.com/legal/privacy">Privacy</a> | <a href="http://www.esri.com/legal">Legal</a></small></p>
+              <p><small>Copyright © 2021 Esri. All rights reserved. | <a href="http://www.esri.com/legal/privacy">Privacy</a> | <a href="http://www.esri.com/legal">Legal</a></small></p>
             </div>
           </div>
         </footer>
@@ -192,6 +192,6 @@ a2a_config.color_link_text = "#497671";
 a2a_config.color_link_text_hover = "#497671";
     </script>
     <script async src="https://static.addtoany.com/menu/page.js"></script>
-    
+
   </body>
 </html>

--- a/docs/resources.html
+++ b/docs/resources.html
@@ -48,11 +48,11 @@
     <div class="card trailer-1">
       <div class="card-content">
           <h3>Start here!</h3>
-  
+
           <a href="https://arcg.is/2timm2E" target="_blank" rel="noopener"><img src="./images/StoryMapThumbnail.png" alt="Story Map thumbnail" width="209" height="81" /></a>
 
           <p>This <a href="https://arcg.is/2timm2E" target="_blank" rel="noopener">comprehensive Story Map</a> highlights <strong>key concepts and best practices for public transit GIS analysis</strong>. It shows how to determine who your transit system serves, how well people are served by transit, and how easy it is for people to access important destinations by transit. The analyses were done using ArcGIS and the tools available on this website. You can also <a href="https://youtu.be/oe-dycALa2w" target="_blank" rel="noopener">watch a narrated version</a> of this Story Map if you want.</p>
-          
+
           <p>Also check out our <a href="https://arcg.is/1nn5bj1" target="_blank" rel="noopener">ArcGIS Public Transportation Quarterly Technology Webcasts</a>.</p>
       </div>
     </div>
@@ -68,12 +68,12 @@
           <li><a href="https://blogs.esri.com/esri/arcgis/2016/07/06/map-the-frequency-of-transit-service-across-your-city-and-find-out-why-it-matters/" target="_blank" rel="noopener">Map the frequency of transit service across your city and find out why it matters</a></li>
           <li><a href="https://blogs.esri.com/esri/arcgis/2018/01/08/mapping-transit-accessibility-to-jobs/" target="_blank" rel="noopener">Mapping transit accessibility to jobs</a></li>
           <li><a href="https://blogs.esri.com/esri/arcgis/2017/07/19/how-to-make-a-shapes-txt-file-for-your-gtfs-dataset-with-arcgis/" target="_blank" rel="noopener">How to make a shapes.txt file for your GTFS dataset with ArcGIS</a></li>
-          <li><a href="https://community.esri.com/community/arcgis-for-public-transit/blog/2020/04/20/transit-safety-management-system" target="_blank" rel="noopener">Transit Safety Management System</a></li>
-          <li><a href="https://community.esri.com/community/arcgis-for-public-transit/blog/2019/12/23/real-time-avl-feeds-with-arcgis" target="_blank" rel="noopener">Real-Time AVL Feeds With ArcGIS</a></li>
-          <li><a href="https://community.esri.com/community/arcgis-for-public-transit/blog/2019/12/17/survey123-and-webhooks-for-transit" target="_blank" rel="noopener">Survey123 and Webhooks for Transit</a></li>
-          <li><a href="https://community.esri.com/blogs/jayhagen/2019/08/15/public-transit-real-estate-solution" target="_blank" rel="noopener">Public Transit Real Estate Solution</a></li>
-          <li><a href="https://community.esri.com/blogs/jayhagen/2019/12/05/transit-incident-reporting" target="_blank" rel="noopener">Transit Incident Reporting</a></li>
-          <li><a href="https://community.esri.com/blogs/jayhagen/2019/12/03/routing-a-fleet-of-vehicle-with-ready-to-use-tools" target="_blank" rel="noopener">Routing a Fleet of Vehicles with Ready-To-Use Tools</a></li>
+          <li><a href="https://community.esri.com/t5/public-transit-blog/transit-safety-management-system/ba-p/882965" target="_blank" rel="noopener">Transit Safety Management System</a></li>
+          <li><a href="https://community.esri.com/t5/public-transit-blog/real-time-avl-feeds-with-arcgis/ba-p/883008" target="_blank" rel="noopener">Real-Time AVL Feeds With ArcGIS</a></li>
+          <li><a href="https://community.esri.com/t5/public-transit-blog/survey123-and-webhooks-for-transit/ba-p/882990" target="_blank" rel="noopener">Survey123 and Webhooks for Transit</a></li>
+          <li><a href="https://community.esri.com/t5/public-transit-blog/public-transit-real-estate-solution/ba-p/883013" target="_blank" rel="noopener">Public Transit Real Estate Solution</a></li>
+          <li><a href="https://community.esri.com/t5/public-transit-blog/transit-incident-reporting/ba-p/882969" target="_blank" rel="noopener">Transit Incident Reporting</a></li>
+          <li><a href="https://community.esri.com/t5/public-transit-blog/routing-a-fleet-of-vehicles-with-ready-to-use/ba-p/882993" target="_blank" rel="noopener">Routing a Fleet of Vehicles with Ready-To-Use Tools</a></li>
           <li><a href="https://community.esri.com/community/gis/web-gis/arcgisonline/blog/2020/02/29/make-your-static-bus-timetables-sing-and-move-along-with-arcade-part-1" target="_blank" rel="noopener">Make your static bus timetables sing and move along with Arcade</a></li>
         </ul>
       </div>
@@ -101,7 +101,7 @@
 
   <!-- End first vertical column -->
   </div>
-  
+
 <!-- Second vertical column -->
   <div class="column-8">
 
@@ -164,14 +164,14 @@
         </ul>
     </div>
     </div>
-    
-    
 
-  
-  
+
+
+
+
   <!-- End second vertical column -->
   </div>
-  
+
   <!-- Begin third vertical column -->
   <div class="column-8">
 
@@ -187,14 +187,14 @@
 
           <li><a href="https://philadelphiafed.org/-/media/community-development/publications/special-reports/public-transit-and-job-access-in-northeastern-pennsylvania/getting-to-work-on-time.pdf" target="_blank" rel="noopener">Getting to Work on Time: Public Transit and Job Access in Northeastern Pennsylvania</a>, a community development study by Kyle DeMaria at the Federal Reserve Bank of Philadelphia</li>
           <li><a href="https://philadelphiafed.org/community-development/publications/special-reports/transit" target="_blank" rel="noopener">Accessing Economic Opportunity: Public Transit, Job Access, and Equitable Economic Development in Three Medium-Sized Regions</a>, another community development study by Kyle DeMaria at the Federal Reserve Bank of Philadelphia</li>
-          
+
           <li><a href="https://cityofmadison.maps.arcgis.com/apps/webappviewer/index.html?id=6a19a38e00be441080923f1f2f862b22" target="_blank" rel="noopener">Active Living Index map</a>, by the City of Madison.  Transit Access to jobs was assessed using the Add GTFS to a Network Dataset tool.</li>
 
           <li><a href="https://geocenter-valleymetro.opendata.arcgis.com/" target="_blank" rel="noopener">Valley Metro GeoCenter</a> - a collection of apps and data using ArcGIS products.  Reach out to them for details on how they clean and aggregate their passenger counter data.</li>
         </ul>
       </div>
     </div>
-  
+
     <!-- Card -->
     <div class="card trailer-1">
       <div class="card-content">
@@ -253,9 +253,9 @@
               </div>
               <!-- AddToAny END -->
               <p class="leader-1"><small>We appreciate your questions, comments, and suggestions.<br />
-              Please post them to our <a href="https://community.esri.com/community/arcgis-for-public-transit" rel="noopener" target="_blank">GeoNet group.<a></small></p>
+              Please post them to the <a href="https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions" rel="noopener" target="_blank">Esri Community forums.<a></small></p>
               <div class="esri-logo"></div>
-              <p><small>Copyright © 2020 Esri. All rights reserved. | <a href="http://www.esri.com/legal/privacy">Privacy</a> | <a href="http://www.esri.com/legal">Legal</a></small></p>
+              <p><small>Copyright © 2021 Esri. All rights reserved. | <a href="http://www.esri.com/legal/privacy">Privacy</a> | <a href="http://www.esri.com/legal">Legal</a></small></p>
             </div>
           </div>
         </footer>
@@ -276,6 +276,6 @@ a2a_config.color_link_text = "#497671";
 a2a_config.color_link_text_hover = "#497671";
     </script>
     <script async src="https://static.addtoany.com/menu/page.js"></script>
-    
+
   </body>
 </html>

--- a/edit-GTFS-stop-locations/README.md
+++ b/edit-GTFS-stop-locations/README.md
@@ -23,7 +23,7 @@ The Edit GTFS Stop Locations toolbox is a set of python script tools that allow 
 
 ## Issues
 
-Find a bug or want to request a new feature?  Please let us know by submitting an issue, or post a question in our [GeoNet group](https://community.esri.com/community/arcgis-for-public-transit).
+Find a bug or want to request a new feature?  Please let us know by submitting an issue, or post a question in the [Esri Community forums](https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions).
 
 ## Contributing
 

--- a/edit-GTFS-stop-locations/UsersGuide.md
+++ b/edit-GTFS-stop-locations/UsersGuide.md
@@ -72,4 +72,4 @@ For detailed information on editing in ArcGIS Pro, read about editing in the [Ar
 - **[Your designated output stops.txt file]**: The new stops.txt file that incorporates the edits you made to the stop locations and attributes.  The stop_lon and stop_lat fields will be automatically updated with the new stop locations. *Note: If you used a shapefile for your stops feature class and you had field names longer than 10 characters that aren't part of the standard GTFS specification, these field names will be truncated to 10 characters in the resulting stops.txt file, and you will have to manually correct them.*
 
 ## Questions or problems?
-Search for answers and post questions in our [GeoNet group](https://community.esri.com/community/arcgis-for-public-transit).
+Search for answers and post questions in the [Esri Community forums](https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions).

--- a/generate-GTFS-shapes/README.md
+++ b/generate-GTFS-shapes/README.md
@@ -25,7 +25,7 @@ The Generate GTFS Shapes toolbox produces a shapes.txt file for your GTFS datase
 
 ## Issues
 
-Find a bug or want to request a new feature?  Please let us know by submitting an issue, or post a question in our [GeoNet group](https://community.esri.com/community/arcgis-for-public-transit).
+Find a bug or want to request a new feature?  Please let us know by submitting an issue, or post a question in the [Esri Community forums](https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions).
 
 ## Contributing
 

--- a/generate-GTFS-shapes/UsersGuide.md
+++ b/generate-GTFS-shapes/UsersGuide.md
@@ -288,4 +288,4 @@ This tool will run very quickly for small GTFS datasets or if you are only updat
 * **I got a warning message saying "Warning! Some shapes had no geometry or 0 length. These shapes were written to shapes.txt, but all shape_dist_traveled values for the shape will have a value of 0.0."**: This occurs if one of the shapes in your Shapes feature class has 0 length or no geometry.  This could occur if the transit line has only two stops, both of which are in the same location.  This is probably an error in the GTFS data.
 
 ## Questions or problems?
-Search for answers and post questions in our [GeoNet group](https://community.esri.com/community/arcgis-for-public-transit).
+Search for answers and post questions in the [Esri Community forums](https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions).

--- a/interpolate-blank-stop-times/README.md
+++ b/interpolate-blank-stop-times/README.md
@@ -23,7 +23,7 @@ The Interpolate Blank Stop Times toolset is a utility for estimating arrival_tim
 
 ## Issues
 
-Find a bug or want to request a new feature?  Please let us know by submitting an issue, or post a question in our [GeoNet group](https://community.esri.com/community/arcgis-for-public-transit).
+Find a bug or want to request a new feature?  Please let us know by submitting an issue, or post a question in the [Esri Community forums](https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions).
 
 ## Contributing
 

--- a/interpolate-blank-stop-times/UsersGuide.md
+++ b/interpolate-blank-stop-times/UsersGuide.md
@@ -75,4 +75,4 @@ This method is fairly simplistic, but it should provide a reasonable estimate fo
 * The tool takes forever to run: For small stop_times.txt files and for files with only a small number of blank stop times, this tool will run fairly quickly.  However, this tool will take a considerable time to run for very large datasets with a large number of blank times.  It may take many hours to complete.  Progress is reported in  increments of 10%.
 
 ## Questions or problems?
-Search for answers and post questions in our [GeoNet group](https://community.esri.com/community/arcgis-for-public-transit).
+Search for answers and post questions in the [Esri Community forums](https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions).

--- a/send-GTFS-rt-to-GeoEvent/README.md
+++ b/send-GTFS-rt-to-GeoEvent/README.md
@@ -24,7 +24,7 @@ Edit the hostname and port in the script to match your environment, i.e. the hos
 
 ## Issues
 
-Find a bug or want to request a new feature?  Please let us know by submitting an issue, or post a question in our [GeoNet group](https://community.esri.com/community/arcgis-for-public-transit).
+Find a bug or want to request a new feature?  Please let us know by submitting an issue, or post a question in the [Esri Community forums](https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions).
 
 ## Contributing
 

--- a/transit-network-analysis-tools-arcmap/README.md
+++ b/transit-network-analysis-tools-arcmap/README.md
@@ -29,7 +29,7 @@ The *Transit Network Analysis Tools* must be used with a transit-enabled network
 
 ## Issues
 
-Find a bug or want to request a new feature?  Please let us know by submitting an issue, or post a question in our [GeoNet group](https://community.esri.com/community/arcgis-for-public-transit).
+Find a bug or want to request a new feature?  Please let us know by submitting an issue, or post a question in the [Esri Community forums](https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions).
 
 ## Contributing
 

--- a/transit-network-analysis-tools-arcmap/UsersGuide.md
+++ b/transit-network-analysis-tools-arcmap/UsersGuide.md
@@ -321,4 +321,4 @@ Inside the calendar.txt file, the weekday fields (monday, tuesday, etc.) define 
 The same principles apply if you created your network dataset from some other, non-GTFS public transit source data.
 
 ## Questions or problems?
-Search for answers and post questions in our [GeoNet group](https://community.esri.com/community/arcgis-for-public-transit).
+Search for answers and post questions in the [Esri Community forums](https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions).

--- a/transit-network-analysis-tools/README.md
+++ b/transit-network-analysis-tools/README.md
@@ -30,7 +30,7 @@ If you are looking for the older version of this toolbox that worked with ArcMap
 
 ## Issues
 
-Find a bug or want to request a new feature?  Please let us know by submitting an issue, or post a question in our [GeoNet group](https://community.esri.com/community/arcgis-for-public-transit).
+Find a bug or want to request a new feature?  Please let us know by submitting an issue, or post a question in the [Esri Community forums](https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions).
 
 ## Contributing
 

--- a/transit-network-analysis-tools/UsersGuide.md
+++ b/transit-network-analysis-tools/UsersGuide.md
@@ -107,7 +107,7 @@ For each origin-destination pair in an OD Cost Matrix layer or each route in a R
 
 You can also choose to save a feature class containing the combined network analysis output for the entire time window. 
 
-Note: Unlike the other tools in this toolbox, this tool has not been overhauled and optimized to run in parallel in ArcGIS Pro. If you are using this tool and performance is a concern for you, please leave a note in our GitHub repo or on our GeoNet page.
+Note: Unlike the other tools in this toolbox, this tool has not been overhauled and optimized to run in parallel in ArcGIS Pro. If you are using this tool and performance is a concern for you, please leave a note in our GitHub repo or on the Esri Community forums.
 
 Running this tool involves two steps:
 
@@ -164,7 +164,7 @@ Note that when this tool runs, if the input OD Cost Matrix layer and the network
 
 The tool will run slower if you have chosen to save the combined network analysis results.
 
-Note: Unlike the other tools in this toolbox, this tool has not been overhauled and optimized to run in parallel in ArcGIS Pro. If you are using this tool and performance is a concern for you, please leave a note in our GitHub repo or on our GeoNet page.
+Note: Unlike the other tools in this toolbox, this tool has not been overhauled and optimized to run in parallel in ArcGIS Pro. If you are using this tool and performance is a concern for you, please leave a note in our GitHub repo or on the Esri Community forums.
 
 
 
@@ -269,4 +269,4 @@ Inside the calendar.txt file, the weekday fields (monday, tuesday, etc.) define 
 The same principles apply if you created your network dataset from some other, non-GTFS public transit source data.
 
 ## Questions or problems?
-Search for answers and post questions in our [GeoNet group](https://community.esri.com/community/arcgis-for-public-transit).
+Search for answers and post questions in the [Esri Community forums](https://community.esri.com/t5/public-transit-questions/bd-p/public-transit-questions).


### PR DESCRIPTION
Various internal pages were reorganized with the Esri Community user forums (formerly known as GeoNet). Update all URLs in readmes, user's guides, and website pages.

No tool code change. This is just housekeeping.