### PR TITLE
Handle edge case where direction_id has blank values

### DIFF
--- a/better-bus-buffers/BBB_CountTripsAtStopsByRouteAndDirection.py
+++ b/better-bus-buffers/BBB_CountTripsAtStopsByRouteAndDirection.py
@@ -263,12 +263,7 @@ def runTool(output_stop_file, SQLDbase, time_window_value_table, snap_to_nearest
                 row += vals
 
             # Insert the row
-            try:
-                cur3.insertRow(row)
-            except:
-                arcpy.AddError("Error inserting row. direction_id:")
-                arcpy.AddError(direction_id)
-                arcpy.AddError(type(direction_id))
+            cur3.insertRow(row)
 
         # Insert row for any remaining stops that were not used at all
         for stop_id in used_stops:

--- a/better-bus-buffers/BBB_CountTripsAtStopsByRouteAndDirection.py
+++ b/better-bus-buffers/BBB_CountTripsAtStopsByRouteAndDirection.py
@@ -3,8 +3,8 @@
 ## Created by: David Wasserman, https://github.com/d-wasserman and Melinda Morang, Esri
 ## This tool was developed as part of Transit R&D Efforts from Fehr & Peers.
 ## Fehr & Peers contributes this tool to the BBB Toolset to further more
-## informed planning. 
-## Last updated: 8 October 2020
+## informed planning.
+## Last updated: 25 September 2021
 ############################################################################
 ''' BetterBusBuffers - Count Trips at Stops by Route and Direction
 
@@ -18,7 +18,7 @@ combination of stop id, route id, and direction id, and the frequency statistics
 that relate to each of them for the analyzed time window.
 '''
 ################################################################################
-'''Copyright 2020 Esri
+'''Copyright 2021 Esri
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
@@ -58,7 +58,7 @@ limitations under the License.
 ################################################################################
 import arcpy
 import BBB_SharedFunctions
-import sqlite3, os, datetime
+import sqlite3
 
 def runTool(output_stop_file, SQLDbase, time_window_value_table, snap_to_nearest_5_minutes):
     def RetrieveFrequencyStatsForStop(stop_id, stoptimedict, start_sec, end_sec):
@@ -108,9 +108,10 @@ def runTool(output_stop_file, SQLDbase, time_window_value_table, snap_to_nearest
     triproutefetch = '''SELECT DISTINCT route_id,direction_id FROM trips;'''
     c.execute(triproutefetch)
     for rtpair in c.fetchall():
-        key = tuple(rtpair)
         route_id = rtpair[0]
         direction_id = rtpair[1]
+        if str(direction_id).strip() == "":  # Handle blanks
+            direction_id = None
         # Get list of trips
         # Ignore direction if this route doesn't have a direction
         if direction_id is not None and str(direction_id).strip():
@@ -123,6 +124,7 @@ def runTool(output_stop_file, SQLDbase, time_window_value_table, snap_to_nearest
                     WHERE route_id = '{0}';'''.format(route_id)
         c.execute(triproutefetch)
         triproutelist = c.fetchall()
+        key = (route_id, direction_id)
         trip_route_dict[key] = triproutelist
 
     # ----- For each time window, calculate the stop frequency -----
@@ -152,7 +154,6 @@ def runTool(output_stop_file, SQLDbase, time_window_value_table, snap_to_nearest
             BBB_SharedFunctions.GetServiceIDListsAndNonOverlaps(day, start_sec, end_sec, DepOrArr, Specific)
 
         # Retrieve the stop_times for the time window broken out by route/direction
-        stoproutedir_dict = {}  # {(stop_id, route_id, direction_id): [NumTrips, NumTripsPerHour, MaxWaitTimeSec, AvgHeadwayMin]}
         for rtdirpair in trip_route_dict:
             # Get trips running with these service_ids
             trip_serv_list = trip_route_dict[rtdirpair]
@@ -229,7 +230,7 @@ def runTool(output_stop_file, SQLDbase, time_window_value_table, snap_to_nearest
     ] + new_fields
     with arcpy.da.InsertCursor(output_stop_file, fields) as cur3:
         # Iterate over all unique stop, route_id, direction_id groups and insert values
-        for key in sorted(final_stop_freq_dict.keys()):
+        for key in sorted(final_stop_freq_dict.keys(), key=lambda x: (x[0], x[1], x[2] if x[2] is not None else -1)):
             stop_id = key[0]
             used_stops[stop_id] = True
             route_id = key[1]
@@ -262,7 +263,12 @@ def runTool(output_stop_file, SQLDbase, time_window_value_table, snap_to_nearest
                 row += vals
 
             # Insert the row
-            cur3.insertRow(row)
+            try:
+                cur3.insertRow(row)
+            except:
+                arcpy.AddError("Error inserting row. direction_id:")
+                arcpy.AddError(direction_id)
+                arcpy.AddError(type(direction_id))
 
         # Insert row for any remaining stops that were not used at all
         for stop_id in used_stops:


### PR DESCRIPTION
The Count Trips At Stops By Route And Direction tool throws errors in both ArcMap and Pro if the GTFS data had blank values for direction_id. This is kind of a data error, but the GTFS spec and the best practices site don't _explicitly_ say you can't have blank values.

This bug was pointed out by @drewlevitt, and he took a stab at fixing it in this PR: https://github.com/Esri/public-transit-tools/pull/159/files.  He addressed the problem, but there were two things about his fix that were slightly less than ideal:
- Blank direction_ids were encoded as 0s instead of left blank. I think this potentially messes up the count statistics since technically None is a different direction than 1 or 0. That said, who knows what the data creator intended since the data is technically invalid...
- Sorting of the output rows was removed. Sorting isn't strictly necessary since the data would still be correct, but I think it makes it easier to read the results when they are neatly sorted.

So, my pull request uses the ideas from @drewlevitt's original one but allows blank direction_ids to be passed all the way through as None/null, and it maintains the sorting in the output using an ugly lambda function.

The fix has been tested in both ArcMap and Pro.