### PR TITLE
Fix ObjectID issue in Calculate Accessibility Matrix

### DIFF
--- a/transit-network-analysis-tools/parallel_odcm.py
+++ b/transit-network-analysis-tools/parallel_odcm.py
@@ -263,8 +263,12 @@ class ODCostMatrix:  # pylint:disable = too-many-instance-attributes
             try:
                 setattr(self.od_solver, prop, OD_PROPS[prop])
             except Exception as ex:  # pylint: disable=broad-except
-                self.logger.warning(f"Failed to set property {prop} from OD config file. Default will be used instead.")
-                self.logger.warning(str(ex))
+                # Suppress warnings for search tolerance for older services (pre 11.0) that don't support locate
+                # settings because we don't want the tool to always throw a warning.
+                if not (self.is_service and prop in ["searchTolerance", "searchToleranceUnits"]):
+                    self.logger.warning(
+                        f"Failed to set property {prop} from OD config file. Default will be used instead.")
+                    self.logger.warning(str(ex))
         # Set properties explicitly specified in the tool UI as arguments
         self.logger.debug("Setting OD Cost Matrix analysis properties specified tool inputs...")
         self.od_solver.travelMode = self.travel_mode

--- a/transit-network-analysis-tools/parallel_odcm.py
+++ b/transit-network-analysis-tools/parallel_odcm.py
@@ -802,7 +802,8 @@ class ParallelODCalculator():
         # Append the calculated transit frequency statistics to the output feature class
         LOGGER.debug("Writing data to output Origins...")
         arcpy.management.AddFields(self.origins, field_defs)
-        fields = ["ObjectID"] + [f[0] for f in field_defs]
+        oid_field = arcpy.Describe(self.origins).oidFieldName
+        fields = [oid_field] + [f[0] for f in field_defs]
         with arcpy.da.UpdateCursor(self.origins, fields) as cur:  # pylint: disable=no-member
             for row in cur:
                 oid = row[0]

--- a/transit-network-analysis-tools/parallel_sa.py
+++ b/transit-network-analysis-tools/parallel_sa.py
@@ -236,8 +236,12 @@ class ServiceArea:  # pylint:disable = too-many-instance-attributes
             try:
                 setattr(self.sa_solver, prop, SA_PROPS[prop])
             except Exception as ex:  # pylint: disable=broad-except
-                self.logger.warning(f"Failed to set property {prop} from SA config file. Default will be used instead.")
-                self.logger.warning(str(ex))
+                # Suppress warnings for search tolerance for older services (pre 11.0) that don't support locate
+                # settings because we don't want the tool to always throw a warning.
+                if not (self.is_service and prop in ["searchTolerance", "searchToleranceUnits"]):
+                    self.logger.warning(
+                        f"Failed to set property {prop} from SA config file. Default will be used instead.")
+                    self.logger.warning(str(ex))
         # Set properties explicitly specified in the tool UI as arguments
         self.logger.debug("Setting Service Area analysis properties specified as tool inputs...")
         self.sa_solver.travelMode = self.travel_mode


### PR DESCRIPTION
If the input feature classes used an alternate field name for the ObjectID, the code did not properly map the output statistics to the correct input rows.  Small change to use the input feature class's ObjectID field name instead of assuming that it's `ObjectID`.

This bug was reported on the Esri Community here: https://community.esri.com/t5/public-transit-questions/calculate-accessibility-matrix-inconsistent/m-p/1167960

Also, future proof some warning messages for the upcoming Pro 3.0 release (unrelated change).