### PR TITLE
Calculate Accessibility Matrix: Don't pass the weight field if it isn't populated

### DIFF
--- a/transit-network-analysis-tools/CalculateODMatrixInParallel.py
+++ b/transit-network-analysis-tools/CalculateODMatrixInParallel.py
@@ -606,9 +606,10 @@ class CalculateAccessibilityMatrix(ODCostMatrixSolver):  # pylint: disable=too-m
             "--origins", self.origins_for_od,
             "--destinations", self.temp_destinations,
             "--time-units", self.time_units,
-            "--cutoff", str(self.cutoff),
-            "--weight-field", self.weight_field
+            "--cutoff", str(self.cutoff)
         ]
+        if self.weight_field:
+            self.tool_specific_od_inputs += ["--weight-field", self.weight_field]
         super()._execute_solve()
 
         # If the input origins were polygons, post-process the OD points to join the output fields back


### PR DESCRIPTION
Fix a bug introduced when I refactored the tool for parallelization. Don't attempt to pass the weight field to the subprocess if the weight field is None because the subprocess converts the NoneType object to a string "None".

Reported by a user.