### PR TITLE
Properly close logging handlers in parallel processes

### DIFF
--- a/transit-network-analysis-tools/parallel_cpap.py
+++ b/transit-network-analysis-tools/parallel_cpap.py
@@ -142,6 +142,11 @@ def parallel_counter(time_lapse_polygons, raster_template, scratch_folder, combo
     logger.info(f"Finished dissolve in {time.time() - t0} seconds.")
     job_result["polygons"] = dissolved_polygons
 
+    # Clean up and close the logger.
+    for handler in logger.handlers:
+        handler.close()
+        logger.removeHandler(handler)
+
     return job_result
 
 

--- a/transit-network-analysis-tools/parallel_odcm.py
+++ b/transit-network-analysis-tools/parallel_odcm.py
@@ -13,7 +13,7 @@ window.  The number of reachable destinations can be weighted based on a field,
 such as the number of jobs available at each destination.  The tool also
 calculates the percentage of total destinations reachable.
 
-This script should be launched by the CalculateAccessibilityMatrixInParallel.py
+This script should be launched by the CalculateODMatrixInParallel.py
 script as a subprocess. It computes the OD Cost Matrix in parallel for all time
 increments, chunking the origins and destinations if necessary, and calculates
 the desired statistics on the outputs.
@@ -549,6 +549,12 @@ class ODCostMatrix:  # pylint:disable = too-many-instance-attributes
             file_handler.setFormatter(formatter)
             logger_obj.addHandler(file_handler)
 
+    def teardown_logger(self):
+        """Clean up and close the logger."""
+        for handler in self.logger.handlers:
+            handler.close()
+            self.logger.removeHandler(handler)
+
 
 def solve_od_cost_matrix(inputs, chunk):
     """Solve an OD Cost Matrix analysis for the given inputs for the given chunk of ObjectIDs.
@@ -569,6 +575,7 @@ def solve_od_cost_matrix(inputs, chunk):
         f"for start time {chunk[2]} as job id {odcm.job_id}"
     ))
     odcm.solve(chunk[0], chunk[1], chunk[2])
+    odcm.teardown_logger()
     return odcm.job_result
 
 
@@ -700,9 +707,7 @@ class ParallelODCalculator():
         finally:
             if odcm:
                 # Close logging and delete the temporary log file
-                for handler in odcm.logger.handlers:
-                    handler.close()
-                    odcm.logger.removeHandler(handler)
+                odcm.teardown_logger()
                 os.remove(odcm.log_file)
 
     @staticmethod

--- a/transit-network-analysis-tools/parallel_sa.py
+++ b/transit-network-analysis-tools/parallel_sa.py
@@ -387,6 +387,12 @@ class ServiceArea:  # pylint:disable = too-many-instance-attributes
             file_handler.setFormatter(formatter)
             logger_obj.addHandler(file_handler)
 
+    def teardown_logger(self):
+        """Clean up and close the logger."""
+        for handler in self.logger.handlers:
+            handler.close()
+            self.logger.removeHandler(handler)
+
 
 def solve_service_area(inputs, time_of_day):
     """Solve a Service Area analysis for the given time of day.
@@ -403,6 +409,7 @@ def solve_service_area(inputs, time_of_day):
         f"Processing start time {time_of_day} as job id {sa.job_id}"
     ))
     sa.solve(time_of_day)
+    sa.teardown_logger()
     return sa.job_result
 
 
@@ -504,6 +511,7 @@ class ParallelSACalculator():
         finally:
             if sa:
                 LOGGER.debug("Deleting temporary test Service Area job folder...")
+                sa.teardown_logger()
                 shutil.rmtree(sa.job_result["jobFolder"], ignore_errors=True)
                 del sa
 


### PR DESCRIPTION
Need to properly close logging handlers because users could run into an OSError for ludicrously large problems.