### PR TITLE
Minor update for compatibility with ArcGIS Pro 3.1

### DIFF
--- a/transit-network-analysis-tools/AnalysisHelpers.py
+++ b/transit-network-analysis-tools/AnalysisHelpers.py
@@ -24,6 +24,7 @@ import arcpy
 
 # Determine if this is python 3 (which means probably ArcGIS Pro)
 isPy3 = sys.version_info > (3, 0)
+arcgis_version = arcpy.GetInstallInfo()["Version"]
 
 # Set some shared global variables that can be referenced from the other scripts
 MSG_STR_SPLITTER = " | "

--- a/transit-network-analysis-tools/parallel_odcm.py
+++ b/transit-network-analysis-tools/parallel_odcm.py
@@ -445,10 +445,11 @@ class ODCostMatrix:  # pylint:disable = too-many-instance-attributes
         """Save the OD Lines result to a CSV file."""
         self.logger.debug(f"Saving OD cost matrix Lines output to CSV as {out_csv_file}.")
 
-        # For services solve, properly populate OriginOID and DestinationOID fields in the output Lines. Services do
-        # not preserve the original input OIDs, instead resetting from 1, unlike solves using a local network dataset,
-        # so this extra post-processing step is necessary.
-        if self.is_service:
+        # For services solve in pre-3.0 versions of ArcGIS Pro, export Origins and Destinations and properly populate
+        # OriginOID and DestinationOID fields in the output Lines. Services do not preserve the original input OIDs,
+        # instead resetting from 1, unlike solves using a local network dataset.  This issue was handled on the client
+        # side in the ArcGIS Pro 3.1 release, but for older software, this extra post-processing step is necessary.
+        if self.is_service and AnalysisHelpers.arcgis_version < "3.1":
             # Read the Lines output
             with self.solve_result.searchCursor(
                 arcpy.nax.OriginDestinationCostMatrixOutputDataType.Lines, self.output_fields


### PR DESCRIPTION
In the ArcGIS Pro 3.1 release, we made some improvements to the arcpy.nax solver objects, particularly in the area of ensuring reliable relationships between the output classes using OID and ID fields. This PR makes minor updates to the tool code to ensure continuing compatibility with older versions of ArcGIS Pro and compatibility with the forthcoming 3.1 release.