### PR TITLE
Update CreateTimeLapsePolygons_SA_config.py

### DIFF
--- a/transit-network-analysis-tools/CreateTimeLapsePolygons_SA_config.py
+++ b/transit-network-analysis-tools/CreateTimeLapsePolygons_SA_config.py
@@ -42,7 +42,7 @@ SA_PROPS = {
     "outputType": arcpy.nax.ServiceAreaOutputType.Polygons,  # Tool won't work if you change this.
     "overrides": "",
     "polygonBufferDistance": 100,
-    "polygonBufferDistance": arcpy.nax.DistanceUnits.Meters,
+    "polygonBufferDistanceUnits": arcpy.nax.DistanceUnits.Meters,
     "polygonDetail": arcpy.nax.ServiceAreaPolygonDetail.High,
     # "searchQuery": [],  # This parameter is very network specific. Only uncomment if you are using it.
     "searchTolerance": 500,


### PR DESCRIPTION
Line 45. There were two instances of "polygonBufferDistance" setting. The second instance relating to units has been changed to "polygonBufferDistanceUnits".

I was having a bug where "polygonDetail" changes were not feeding into my results and only took hold once I fixed the above issue.