### PR TITLE
Fix unicode decode error

### DIFF
--- a/transit-network-analysis-tools/AnalysisHelpers.py
+++ b/transit-network-analysis-tools/AnalysisHelpers.py
@@ -708,6 +708,26 @@ def execute_subprocess(script_name, inputs):
             raise RuntimeError(err)
 
 
+def configure_global_logger(log_level):
+    """Configure a global logger for the main process.
+
+    The logger logs everything from the main process to stdout using a specific format that the tools in this
+    toolbox can parse and write to the geoprocessing message feed.
+
+    Args:
+        log_level: logging module message level, such as logging.INFO or logging.DEBUG.
+    """
+    logger = logging.getLogger(__name__)  # pylint:disable=invalid-name
+    logger.setLevel(log_level)
+    sys.stdout.reconfigure(encoding="utf-8")
+    console_handler = logging.StreamHandler(stream=sys.stdout)
+    console_handler.setLevel(log_level)
+    # Used by script tool to split message text from message level to add correct message type to GP window
+    console_handler.setFormatter(logging.Formatter("%(levelname)s" + MSG_STR_SPLITTER + "%(message)s"))
+    logger.addHandler(console_handler)
+    return logger
+
+
 class PrecalculateLocationsMixin:  # pylint:disable = too-few-public-methods
     """Used to precalculate network locations either directly or calling the parallelized version."""
 

--- a/transit-network-analysis-tools/AnalysisHelpers.py
+++ b/transit-network-analysis-tools/AnalysisHelpers.py
@@ -685,7 +685,7 @@ def execute_subprocess(script_name, inputs):
         while process.poll() is None:
             output = process.stdout.readline()
             if output:
-                msg_string = output.strip().decode()
+                msg_string = output.strip().decode(encoding="utf-8")
                 parse_std_and_write_to_gp_ui(msg_string)
             time.sleep(.1)
 
@@ -694,7 +694,7 @@ def execute_subprocess(script_name, inputs):
         # messages from raised exceptions, especially those with tracebacks.
         output, _ = process.communicate()
         if output:
-            out_msgs = output.decode().splitlines()
+            out_msgs = output.decode(encoding="utf-8").splitlines()
             for msg in out_msgs:
                 parse_std_and_write_to_gp_ui(msg)
 
@@ -815,7 +815,7 @@ class LoggingMixin:
 
         self.logger.setLevel(logging.DEBUG)
         if len(self.logger.handlers) <= 1:
-            file_handler = logging.FileHandler(self.log_file)
+            file_handler = logging.FileHandler(self.log_file, encoding="utf-8")
             file_handler.setLevel(logging.DEBUG)
             self.logger.addHandler(file_handler)
             formatter = logging.Formatter("%(process)d | %(message)s")

--- a/transit-network-analysis-tools/AnalysisHelpers.py
+++ b/transit-network-analysis-tools/AnalysisHelpers.py
@@ -49,6 +49,7 @@ FIELDS_TO_PRESERVE = [FACILITY_ID_FIELD, NAME_FIELD, FROM_BREAK_FIELD, TO_BREAK_
 
 class TransitNetworkAnalysisToolsError(Exception):
     """Generic error class that can be raised for known problems in these tools."""
+
     pass
 
 
@@ -63,11 +64,11 @@ def validate_input_feature_class(feature_class):
         ValueError: The input feature class has no rows.
     """
     if not arcpy.Exists(feature_class):
-        err = "Input dataset %s does not exist." % feature_class
+        err = f"Input dataset {feature_class} does not exist."
         arcpy.AddError(err)
         raise ValueError(err)
     if int(arcpy.management.GetCount(feature_class).getOutput(0)) <= 0:
-        err = "Input dataset %s has no rows." % feature_class
+        err = f"Input dataset {feature_class} has no rows."
         arcpy.AddError(err)
         raise ValueError(err)
 
@@ -241,8 +242,7 @@ def get_catalog_path(layer):
     """
     if hasattr(layer, "dataSource"):
         return layer.dataSource
-    else:
-        return layer
+    return layer
 
 
 def get_catalog_path_from_param(param):
@@ -256,8 +256,7 @@ def get_catalog_path_from_param(param):
     """
     if hasattr(param.value, "dataSource"):
         return param.value.dataSource
-    else:
-        return param.valueAsText
+    return param.valueAsText
 
 
 def are_input_layers_the_same(input_layer_1, input_layer_2):
@@ -292,9 +291,7 @@ def are_input_layers_the_same(input_layer_1, input_layer_2):
 
 def make_analysis_time_of_day_list(start_day_input, end_day_input, start_time_input, end_time_input, increment_input):
     """Make a list of datetimes to use as input for a network analysis time of day run in a loop"""
-
     start_time, end_time = convert_inputs_to_datetimes(start_day_input, end_day_input, start_time_input, end_time_input)
-
     # How much to increment the time in each solve, in minutes
     increment = datetime.timedelta(minutes=increment_input)
     timelist = []  # Actual list of times to use for the analysis.
@@ -302,16 +299,13 @@ def make_analysis_time_of_day_list(start_day_input, end_day_input, start_time_in
     while t <= end_time:
         timelist.append(t)
         t += increment
-
     return timelist
 
 
 def convert_inputs_to_datetimes(start_day_input, end_day_input, start_time_input, end_time_input):
     """Parse start and end day and time from tool inputs and convert them to datetimes"""
-
-    # For an explanation of special ArcMap generic weekday dates, see the time_of_day parameter
-    # description in the Make Service Area Layer tool documentation
-    # http://desktop.arcgis.com/en/arcmap/latest/tools/network-analyst-toolbox/make-service-area-layer.htm
+    # For an explanation of special generic weekday dates, see this documentation:
+    # https://pro.arcgis.com/en/pro-app/latest/help/analysis/networks/dates-and-times.htm
     days = {
         "Monday": datetime.datetime(1900, 1, 1),
         "Tuesday": datetime.datetime(1900, 1, 2),
@@ -319,11 +313,12 @@ def convert_inputs_to_datetimes(start_day_input, end_day_input, start_time_input
         "Thursday": datetime.datetime(1900, 1, 4),
         "Friday": datetime.datetime(1900, 1, 5),
         "Saturday": datetime.datetime(1900, 1, 6),
-        "Sunday": datetime.datetime(1899, 12, 31)}
+        "Sunday": datetime.datetime(1899, 12, 31)
+    }
 
     # Lower end of time window (HH:MM in 24-hour time)
     generic_weekday = False
-    if start_day_input in days: # Generic weekday
+    if start_day_input in days:  # Generic weekday
         generic_weekday = True
         start_day = days[start_day_input]
     else:  # Specific date

--- a/transit-network-analysis-tools/CreatePercentAccessPolygon.py
+++ b/transit-network-analysis-tools/CreatePercentAccessPolygon.py
@@ -172,7 +172,7 @@ class PercentAccessPolygonCalculator():
             while process.poll() is None:
                 output = process.stdout.readline()
                 if output:
-                    msg_string = output.strip().decode()
+                    msg_string = output.strip().decode(encoding="utf-8")
                     AnalysisHelpers.parse_std_and_write_to_gp_ui(msg_string)
                 time.sleep(.1)
 
@@ -181,7 +181,7 @@ class PercentAccessPolygonCalculator():
             # messages from raised exceptions, especially those with tracebacks.
             output, _ = process.communicate()
             if output:
-                out_msgs = output.decode().splitlines()
+                out_msgs = output.decode(encoding="utf-8").splitlines()
                 for msg in out_msgs:
                     AnalysisHelpers.parse_std_and_write_to_gp_ui(msg)
 

--- a/transit-network-analysis-tools/parallel_calculate_locations.py
+++ b/transit-network-analysis-tools/parallel_calculate_locations.py
@@ -33,7 +33,6 @@ Copyright 2023 Esri
 # pylint: disable=logging-fstring-interpolation
 from concurrent import futures
 import os
-import sys
 import uuid
 import logging
 import shutil
@@ -45,21 +44,10 @@ import arcpy
 
 import AnalysisHelpers
 
-arcpy.env.overwriteOutput = True
-
-# Set logging for the main process.
-# LOGGER logs everything from the main process to stdout using a specific format that the calling tool
-# can parse and write to the geoprocessing message feed.
-LOG_LEVEL = logging.INFO  # Set to logging.DEBUG to see verbose debug messages
-LOGGER = logging.getLogger(__name__)  # pylint:disable=invalid-name
-LOGGER.setLevel(LOG_LEVEL)
-console_handler = logging.StreamHandler(stream=sys.stdout)
-console_handler.setLevel(LOG_LEVEL)
-# Used by script tool to split message text from message level to add correct message type to GP window
-console_handler.setFormatter(logging.Formatter("%(levelname)s" + AnalysisHelpers.MSG_STR_SPLITTER + "%(message)s"))
-LOGGER.addHandler(console_handler)
-
 DELETE_INTERMEDIATE_OUTPUTS = True  # Set to False for debugging purposes
+
+# Change logging.INFO to logging.DEBUG to see verbose debug messages
+LOGGER = AnalysisHelpers.configure_global_logger(logging.INFO)
 
 
 class LocationCalculator(
@@ -426,4 +414,5 @@ def launch_parallel_calc_locs():
 
 if __name__ == "__main__":
     # This script should always be launched via subprocess as if it were being called from the command line.
-    launch_parallel_calc_locs()
+    with arcpy.EnvManager(overwriteOutput=True):
+        launch_parallel_calc_locs()

--- a/transit-network-analysis-tools/parallel_cpap.py
+++ b/transit-network-analysis-tools/parallel_cpap.py
@@ -1,7 +1,7 @@
 ############################################################################
 ## Tool name: Transit Network Analysis Tools
 ## Created by: Melinda Morang, Esri
-## Last updated: 20 March 2023
+## Last updated: 7 June 2023
 ############################################################################
 """Do the core logic for the Create Percent Access Polygons tool in parallel
 for maximum efficiency.
@@ -21,7 +21,6 @@ Copyright 2023 Esri
 """
 # pylint: disable=logging-fstring-interpolation
 from concurrent import futures
-import sys
 import os
 import time
 import uuid
@@ -30,23 +29,14 @@ import traceback
 import argparse
 import logging
 import arcpy
-
+import AnalysisHelpers
 from AnalysisHelpers import FACILITY_ID_FIELD, FROM_BREAK_FIELD, TO_BREAK_FIELD, TIME_FIELD, FIELDS_TO_PRESERVE, \
-                            MSG_STR_SPLITTER, MAX_RETRIES
+                            MAX_RETRIES
 
-# Set logging for the main process.
-# LOGGER logs everything from the main process to stdout using a specific format that the tool
-# can parse and write to the geoprocessing message feed.
-LOG_LEVEL = logging.INFO  # Set to logging.DEBUG to see verbose debug messages
-LOGGER = logging.getLogger(__name__)  # pylint:disable=invalid-name
-LOGGER.setLevel(LOG_LEVEL)
-console_handler = logging.StreamHandler(stream=sys.stdout)
-console_handler.setLevel(LOG_LEVEL)
-# Used by script tool to split message text from message level to add correct message type to GP window
-console_handler.setFormatter(logging.Formatter("%(levelname)s" + MSG_STR_SPLITTER + "%(message)s"))
-LOGGER.addHandler(console_handler)
+DELETE_INTERMEDIATE_OUTPUTS = True  # Set to False for debugging purposes
 
-DELETE_INTERMEDIATE_OD_OUTPUTS = True  # Set to False for debugging purposes
+# Change logging.INFO to logging.DEBUG to see verbose debug messages
+LOGGER = AnalysisHelpers.configure_global_logger(logging.INFO)
 
 
 def parallel_counter(time_lapse_polygons, raster_template, scratch_folder, combo):
@@ -263,7 +253,7 @@ def count_percent_access_polygons(time_lapse_polygons, raster_template, output_f
 
     # Cleanup
     # Delete the job folders if the job succeeded
-    if DELETE_INTERMEDIATE_OD_OUTPUTS:
+    if DELETE_INTERMEDIATE_OUTPUTS:
         LOGGER.info("Deleting intermediate outputs...")
         try:
             shutil.rmtree(scratch_folder, ignore_errors=True)

--- a/transit-network-analysis-tools/parallel_odcm.py
+++ b/transit-network-analysis-tools/parallel_odcm.py
@@ -1,7 +1,7 @@
 ############################################################################
 ## Tool name: Transit Network Analysis Tools
 ## Created by: Melinda Morang, Esri
-## Last updated: 13 April 2023
+## Last updated: 7 June 2023
 ############################################################################
 """Count the number of destinations reachable from each origin by transit and
 walking. The tool calculates an Origin-Destination Cost Matrix for each start
@@ -37,7 +37,6 @@ Copyright 2023 Esri
 # pylint: disable=logging-fstring-interpolation
 from concurrent import futures
 import os
-import sys
 import uuid
 import logging
 import shutil
@@ -69,21 +68,10 @@ import CalculateAccessibilityMatrix_OD_config
 import CalculateTravelTimeStatistics_OD_config
 import AnalysisHelpers
 
-arcpy.env.overwriteOutput = True
-
-# Set logging for the main process.
-# LOGGER logs everything from the main process to stdout using a specific format that the SolveLargeODCostMatrix tool
-# can parse and write to the geoprocessing message feed.
-LOG_LEVEL = logging.INFO  # Set to logging.DEBUG to see verbose debug messages
-LOGGER = logging.getLogger(__name__)  # pylint:disable=invalid-name
-LOGGER.setLevel(LOG_LEVEL)
-console_handler = logging.StreamHandler(stream=sys.stdout)
-console_handler.setLevel(LOG_LEVEL)
-# Used by script tool to split message text from message level to add correct message type to GP window
-console_handler.setFormatter(logging.Formatter("%(levelname)s" + AnalysisHelpers.MSG_STR_SPLITTER + "%(message)s"))
-LOGGER.addHandler(console_handler)
-
 DELETE_INTERMEDIATE_OD_OUTPUTS = True  # Set to False for debugging purposes
+
+# Change logging.INFO to logging.DEBUG to see verbose debug messages
+LOGGER = AnalysisHelpers.configure_global_logger(logging.INFO)
 
 
 class ODCostMatrix(
@@ -1083,4 +1071,5 @@ def launch_parallel_od():
 
 if __name__ == "__main__":
     # This script should always be launched via subprocess as if it were being called from the command line.
-    launch_parallel_od()
+    with arcpy.EnvManager(overwriteOutput=True):
+        launch_parallel_od()

--- a/transit-network-analysis-tools/parallel_sa.py
+++ b/transit-network-analysis-tools/parallel_sa.py
@@ -1,7 +1,7 @@
 ############################################################################
 ## Tool name: Transit Network Analysis Tools
 ## Created by: Melinda Morang, Esri
-## Last updated: 30 May 2023
+## Last updated: 7 June 2023
 ############################################################################
 """Run a Service Area analysis incrementing the time of day over a time window.
 Save the output polygons to a single feature class that can be used to generate
@@ -30,7 +30,6 @@ Copyright 2023 Esri
 # pylint: disable=logging-fstring-interpolation
 from concurrent import futures
 import os
-import sys
 import uuid
 import logging
 import shutil
@@ -44,21 +43,10 @@ import arcpy
 from CreateTimeLapsePolygons_SA_config import SA_PROPS, SA_PROPS_SET_BY_TOOL
 import AnalysisHelpers
 
-arcpy.env.overwriteOutput = True
-
-# Set logging for the main process.
-# LOGGER logs everything from the main process to stdout using a specific format that the SolveLargeServiceArea tool
-# can parse and write to the geoprocessing message feed.
-LOG_LEVEL = logging.INFO  # Set to logging.DEBUG to see verbose debug messages
-LOGGER = logging.getLogger(__name__)  # pylint:disable=invalid-name
-LOGGER.setLevel(LOG_LEVEL)
-console_handler = logging.StreamHandler(stream=sys.stdout)
-console_handler.setLevel(LOG_LEVEL)
-# Used by script tool to split message text from message level to add correct message type to GP window
-console_handler.setFormatter(logging.Formatter("%(levelname)s" + AnalysisHelpers.MSG_STR_SPLITTER + "%(message)s"))
-LOGGER.addHandler(console_handler)
-
 DELETE_INTERMEDIATE_SA_OUTPUTS = True  # Set to False for debugging purposes
+
+# Change logging.INFO to logging.DEBUG to see verbose debug messages
+LOGGER = AnalysisHelpers.configure_global_logger(logging.INFO)
 
 
 def run_gp_tool(tool, tool_args=None, tool_kwargs=None, log_to_use=LOGGER):
@@ -692,4 +680,5 @@ def launch_parallel_sa():
 
 if __name__ == "__main__":
     # This script should always be launched via subprocess as if it were being called from the command line.
-    launch_parallel_sa()
+    with arcpy.EnvManager(overwriteOutput=True):
+        launch_parallel_sa()

--- a/transit-network-analysis-tools/parallel_sa.py
+++ b/transit-network-analysis-tools/parallel_sa.py
@@ -161,9 +161,6 @@ class ServiceArea(
         # process-specific log file.
         self.setup_logger("ServiceArea")
 
-        # Create a job ID and a folder and scratch gdb for this job
-        self.sa_workspace = self._create_output_gdb()
-
         # Set up other instance attributes
         self.is_service = AnalysisHelpers.is_nds_service(self.network_data_source)
         self.sa_solver = None
@@ -314,16 +311,9 @@ class ServiceArea(
         self.logger.debug("Solve succeeded.")
         self.job_result["solveSucceeded"] = True
 
-        # Make output gdb
-        self.logger.debug("Creating output geodatabase for Service Area analysis...")
-        run_gp_tool(
-            arcpy.management.CreateFileGDB,
-            [os.path.dirname(self.sa_workspace), os.path.basename(self.sa_workspace)],
-            log_to_use=self.logger
-        )
-
         # Export the Service Area polygons output to a feature class
-        output_polygons = os.path.join(self.sa_workspace, "output_polygons")
+        out_gdb = self._create_output_gdb()
+        output_polygons = os.path.join(out_gdb, "output_polygons")
         self.logger.debug(f"Exporting Service Area polygons output to {output_polygons}...")
         solve_result.export(arcpy.nax.ServiceAreaOutputDataType.Polygons, output_polygons)
 


### PR DESCRIPTION
A couple of users have gotten errors like "UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe4 in position 81: invalid continuation byte".  It took me a while to fix it because I couldn't reproduce it, and I still don't know exactly what caused it.  However, someone who experienced the problem ran some tests for me and confirmed that the various encoding/decoding changes here resolve the problem.  I think it has something to do with non-ascii characters either in logging to stdout or in filepath names of temporary files or scratch folders or something.

I also fixed a bug where the parallel service area calculation was trying to create the same geodatabase twice.

Resolves https://github.com/Esri/public-transit-tools/issues/170.