### PR TITLE
Use public TravelMode .JSON property if available

### DIFF
--- a/transit-network-analysis-tools/CalculateODMatrixInParallel.py
+++ b/transit-network-analysis-tools/CalculateODMatrixInParallel.py
@@ -213,7 +213,13 @@ class ODCostMatrixSolver(
             raise
 
         # Return a JSON string representation of the travel mode to pass to the subprocess
-        return odcm.travelMode._JSON  # pylint: disable=protected-access
+        if hasattr(odcm.travelMode, "JSON"):
+            # Pro 3.7+
+            tm_json = odcm.travelMode.JSON
+        else:
+            # Pre 3.7
+            tm_json = odcm.travelMode._JSON  # pylint: disable=protected-access
+        return tm_json
 
     def _set_od_tool_settings(self, odcm):
         """Set ODCostMatrix solver object properties specific to the tool being run.

--- a/transit-network-analysis-tools/CreateTimeLapsePolygonsInParallel.py
+++ b/transit-network-analysis-tools/CreateTimeLapsePolygonsInParallel.py
@@ -209,7 +209,13 @@ class ServiceAreaSolver():  # pylint: disable=too-many-instance-attributes, too-
             raise
 
         # Return a JSON string representation of the travel mode to pass to the subprocess
-        return sa.travelMode._JSON  # pylint: disable=protected-access
+        if hasattr(sa.travelMode, "JSON"):
+            # Pro 3.7+
+            tm_json = sa.travelMode.JSON
+        else:
+            # Pre 3.7
+            tm_json = sa.travelMode._JSON  # pylint: disable=protected-access
+        return tm_json
 
     def _precalculate_network_locations(self, input_features):
         """Precalculate network location fields if possible for faster loading and solving later.


### PR DESCRIPTION
This is a future-proofing PR to ensure that the tools continue to work with both past and future versions of ArcGIS Pro.  Use the public arcpy.nax.TravelMode `.JSON` property if available.