### PR TITLE
Fix Concurrent Use licensing issue

### DIFF
--- a/transit-network-analysis-tools/AnalysisHelpers.py
+++ b/transit-network-analysis-tools/AnalysisHelpers.py
@@ -911,6 +911,7 @@ class MakeNDSLayerMixin:  # pylint:disable = too-few-public-methods
 
     def _make_nds_layer(self):
         """Create a network dataset layer if one does not already exist."""
+        arcpy.CheckOutExtension("network")
         nds_layer_name = os.path.basename(self.network_data_source)
         if arcpy.Exists(nds_layer_name):
             # The network dataset layer already exists in this process, so we can re-use it without having to spend


### PR DESCRIPTION
Starting in Pro 3.6, something changed in when the Network Analyst extension license is checked, which was causing licensing errors in this tool. Strategically check out the extension license before creating a network dataset layer. This fixes the problem.

Note: This problem only occurs with Concurrent Use licensing, which is currently deprecated. Users need to switch to Single Use or Named User soon anyway, but this workaround will help those who can't for the moment.